### PR TITLE
Render documentation in format that Antora understands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ## Ignore tool output
 inventory
+docs/modules
 
 
 ## From here: GitHub's gitignore template for Python

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+MAKEFLAGS += -j4
+
+docker_cmd  ?= docker
+docker_opts ?= --rm --tty --user "$$(id -u)"
+
+vale_cmd           ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/docs/modules/ROOT/pages:/pages vshn/vale:2.6.1 --minAlertLevel=error --config=/pages/.vale.ini /pages
+antora_preview_cmd ?= $(docker_cmd) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora vshn/antora-preview:2.3.7 --style=syn --antora=docs
+
+.PHONY: all
+all: docs
+
+.PHONY: docs-serve
+docs-serve:
+	poetry run commodore-defaults-commentator render git@git.vshn.net:syn/commodore-defaults.git
+	$(antora_preview_cmd)
+
+.PHONY: docs-vale
+docs-vale:
+	$(vale_cmd)

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ docs-serve:
 	poetry run commodore-defaults-commentator render git@git.vshn.net:syn/commodore-defaults.git
 	$(antora_preview_cmd)
 
+.PHONY: preview
+preview:
+	$(antora_preview_cmd)
+
 .PHONY: docs-vale
 docs-vale:
 	$(vale_cmd)

--- a/commodore_defaults_commentator/render.py
+++ b/commodore_defaults_commentator/render.py
@@ -1,13 +1,135 @@
-import reclass
+import os
+
+import yaml
+
+from reclass.utils.parameterdict import ParameterDict
+from reclass.utils.parameterlist import ParameterList
+from reclass.values.value import Value
+
+from commodore.component import component_parameters_key
 
 from . import Config
-from .inventory import AnnotatedInventory
-from .render_template import render_template
+from .inventory import AnnotatedInventoryFactory
+from .render_template import render_template, render_jinja
 
+
+def _represent_value(dumper, data):
+    return dumper.represent_data(data.contents)
+
+
+class YamlAnnotator:
+    def __init__(self):
+        self._annotation_ids = {}
+        self._next_annotation_id = 1
+
+    def _dump_yaml(self, data):
+        d = yaml.SafeDumper
+        d.add_representer(Value, _represent_value)
+        y = yaml.dump(data, default_flow_style=False, Dumper=d)
+        return list(
+            filter(lambda l: l != "..." and l != "", y.split("\n"))
+        )
+
+    def annotate_key(self, key, data, scalar=""):
+        annotationid = None
+        if isinstance(data, ParameterDict) or \
+                isinstance(data, ParameterList) or \
+                isinstance(data, Value):
+            annotationid = self._annotation_ids.setdefault(data.uri, self._next_annotation_id)
+            if annotationid == self._next_annotation_id:
+                self._next_annotation_id += 1
+        annot = ""
+        if annotationid is not None:
+            annot = f" <{annotationid}>"
+        if scalar != "":
+            scalar = f" {scalar}"
+        return f"{key}:{scalar}{annot}"
+
+    def _render_complex_section(self, key, data):
+        output_lines = [self.annotate_key(key, data)]
+        if isinstance(data, ParameterDict) or isinstance(data, dict):
+            for key, value in data.items():
+                output_lines.extend(map(
+                    lambda l: "  " + l,
+                    self._render_complex_section(key, value)
+                ))
+        elif isinstance(data, ParameterList) or isinstance(data, list):
+            # TODO: figure out if we can/want to have locations for individual list items
+            output_lines.extend(map(lambda l: "  " + l, self._dump_yaml(list(data))))
+        elif isinstance(data, Value):
+            output_lines = [self.annotate_key(key, data, scalar=self._dump_yaml(data.contents)[0])]
+        else:
+            output_lines = [self.annotate_key(key, data, scalar=self._dump_yaml(data)[0])]
+        return output_lines
+
+    def asciidoc_yaml_block(self, pkey, cparams, repo_path):
+        if len(cparams) == 0:
+            return "\n".join([
+                "[source,yaml]",
+                "----",
+                f"{pkey}: {{}}",
+                "----"
+            ])
+
+        source_lines = [
+            "[source,yaml]",
+            "----",
+        ]
+        source_lines.extend(self._render_complex_section(pkey, cparams))
+        source_lines.append('----')
+        for loc, annotationid in sorted(self._annotation_ids.items(), key=lambda it: it[1]):
+            loc = strip_prefix(loc, repo_path)
+            source_lines.append(f"<{annotationid}> `{loc}`")
+        return '\n'.join(source_lines)
+
+
+def asciidoc_yaml(params, pkey, repo_path):
+    y = YamlAnnotator()
+    return y.asciidoc_yaml_block(component_parameters_key(pkey), params, repo_path)
+
+def strip_prefix(value, repo_path):
+    if not isinstance(value, str):
+        return value
+    prefix = f"yaml_fs://{repo_path}/"
+    if value.startswith(prefix):
+        return value[len(prefix):]
+    return value
 
 def render_documentation(cfg: Config):
     print(f"Rendering documentation for defaults repo at {cfg.repo}")
-    inv = AnnotatedInventory.from_repo_url(cfg)
-    r = inv.reclass("openshift4", "cloudscale", "lpg")
-    with open('./component_versions.adoc', 'w') as f:
-        f.write(render_template(r))
+    invfactory = AnnotatedInventoryFactory.from_repo_url(cfg)
+
+    docsbase = cfg.workdir / "docs" / "modules" / "ROOT"
+
+    filters = {
+        "asciidoc_yaml": asciidoc_yaml,
+        "strip_prefix": strip_prefix,
+    }
+
+    with open(docsbase / "pages" / "index.adoc", "w") as f:
+        f.write(render_jinja("index.adoc.jinja2", None, repo_url=cfg.repo))
+
+    navitems = {}
+
+    cloud_regions = {
+        "cloudscale": [ "lpg", "rma" ],
+        "exoscale": ["ch-gva-2", "ch-dk-2"],
+    }
+
+    for distribution in [ "openshift4", "openshift3", "rancher", "k3d" ]:
+        navitems[distribution] = {}
+        for cloud in ["cloudscale", "exoscale"]:
+            for region in cloud_regions[cloud]:
+                inv = invfactory.reclass(distribution, cloud, region)
+
+                navitems[distribution][f"{cloud}/{region}"] =  f"{distribution}/{cloud}_{region}.adoc"
+
+                outf = docsbase / "pages" / distribution / f"{cloud}_{region}.adoc"
+                os.makedirs(outf.parent, exist_ok=True)
+
+                with open(outf, 'w') as f:
+                    f.write(render_template(inv, filters))
+
+    navf = docsbase / "nav.adoc"
+    with open(navf, "w") as f:
+        f.write(render_jinja("nav.adoc.jinja2", None, navitems=navitems))

--- a/commodore_defaults_commentator/render.py
+++ b/commodore_defaults_commentator/render.py
@@ -2,14 +2,19 @@ import os
 
 import yaml
 
+from enum import Enum
+from pathlib import Path
+from typing import Iterable
+
 from reclass.utils.parameterdict import ParameterDict
 from reclass.utils.parameterlist import ParameterList
 from reclass.values.value import Value
+from reclass.values.scaitem import ScaItem
 
 from commodore.component import component_parameters_key
 
 from . import Config
-from .inventory import AnnotatedInventoryFactory
+from .inventory import AnnotatedInventoryFactory, value_is_complex
 from .render_template import render_template, render_jinja
 
 
@@ -33,6 +38,21 @@ def _represent_str(dumper, data):
     return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
 
 
+def _represent_parameter_list(dumper, data):
+    annotid = dumper.annotation_ids.setdefault(data.uri, dumper.next_annotation_id)
+    print(f"would annotate with {annotid}")
+    return dumper.represent_list(list(data))
+
+
+def _represent_parameter_dict(dumper, data):
+    annotid = dumper.annotation_ids.setdefault(data.uri, dumper.next_annotation_id)
+    print(f"would annotate with {annotid}")
+    return dumper.represent_dict(dict(data))
+
+def _represent_reference(dumper, data):
+    return dumper.represent_data(f"${{{data.contents}}}")
+
+
 class YamlAnnotator:
     def __init__(self):
         self._annotation_ids = {}
@@ -40,7 +60,12 @@ class YamlAnnotator:
 
     def _dump_yaml(self, data):
         d = yaml.SafeDumper
+        d.annotation_ids = self._annotation_ids
+        d.next_annotation_id = self._next_annotation_id
         d.add_representer(Value, _represent_value)
+        d.add_representer(ParameterList, _represent_parameter_list)
+        d.add_representer(ParameterDict, _represent_parameter_dict)
+        d.add_representer(ScaItem, _represent_reference)
         d.add_representer(str, _represent_str)
         y = yaml.dump(data, default_flow_style=False, Dumper=d)
         return list(
@@ -60,19 +85,35 @@ class YamlAnnotator:
             annot = f" <{annotationid}>"
         if scalar != "":
             scalar = f" {scalar}"
+        if key is None:
+            return f"{scalar}{annot}"
         return f"{key}:{scalar}{annot}"
 
     def _render_complex_section(self, key, data):
         output_lines = [self.annotate_key(key, data)]
         if isinstance(data, ParameterDict) or isinstance(data, dict):
-            for key, value in data.items():
+            for k, value in data.items():
                 output_lines.extend(map(
                     lambda l: "  " + l,
-                    self._render_complex_section(key, value)
+                    self._render_complex_section(k, value)
                 ))
+            if key is None:
+                first = output_lines.pop(0)
+                newout = []
+                extra = []
+                for l in output_lines:
+                    if l.endswith('>'):
+                        newout.append(l)
+                    elif l.endswith(':') or l[3] != " ":
+                        newout.append(f"{l}{first}")
+                    else:
+                        newout.append(l)
+                output_lines = newout
         elif isinstance(data, ParameterList) or isinstance(data, list):
-            # TODO: figure out if we can/want to have locations for individual list items
-            output_lines.extend(map(lambda l: "  " + l, self._dump_yaml(list(data))))
+            for item in data:
+                listit = self._render_complex_section(None, item)
+                output_lines.append(f"  - {listit[0].lstrip()}")
+                output_lines.extend(map(lambda l: "  " + l, listit[1:]))
         else:
             v = data
             if isinstance(v, Value):
@@ -100,7 +141,7 @@ class YamlAnnotator:
         source_lines.append('----')
         for loc, annotationid in sorted(self._annotation_ids.items(), key=lambda it: it[1]):
             loc = strip_prefix(loc, repo_path)
-            source_lines.append(f"<{annotationid}> `{loc}`")
+            source_lines.append(f"<{annotationid}> {loc}")
         return '\n'.join(source_lines)
 
 
@@ -108,19 +149,42 @@ def asciidoc_yaml(params, pkey, repo_path):
     y = YamlAnnotator()
     return y.asciidoc_yaml_block(component_parameters_key(pkey), params, repo_path)
 
+
 def strip_prefix(value, repo_path):
     if not isinstance(value, str):
         return value
     prefix = f"yaml_fs://{repo_path}/"
     if value.startswith(prefix):
-        return value[len(prefix):]
+        return f"`{value[len(prefix):]}`"
+    elif value.endswith("target.yml"):
+        return "cluster fact"
     return value
+
+class DefaultsFact(Enum):
+    DISTRIBUTION = "distribution"
+    CLOUD = "cloud"
+    REGION = "region"
+
+def find_values(fact: DefaultsFact, repo_path: Path, cloud: str = None) -> Iterable[str]:
+    values = []
+    value_path = repo_path / fact.value
+    if fact == DefaultsFact.REGION:
+        if not cloud:
+            raise ValueError(f"cloud must not be None if fact is {fact}")
+        value_path = repo_path / "cloud" / cloud
+    if value_path.is_dir():
+        for f in value_path.iterdir():
+            if f.is_file() and f.suffix == ".yml":
+                values.append(f.stem)
+    return values
+
 
 def render_documentation(cfg: Config):
     print(f"Rendering documentation for defaults repo at {cfg.repo}")
     invfactory = AnnotatedInventoryFactory.from_repo_url(cfg)
 
     docsbase = cfg.workdir / "docs" / "modules" / "ROOT"
+    os.makedirs(docsbase / "pages", exist_ok=True)
 
     filters = {
         "asciidoc_yaml": asciidoc_yaml,
@@ -132,15 +196,21 @@ def render_documentation(cfg: Config):
 
     navitems = {}
 
-    cloud_regions = {
-        "cloudscale": [ "lpg", "rma" ],
-        "exoscale": ["ch-gva-2", "ch-dk-2"],
-    }
 
-    for distribution in [ "openshift4", "openshift3", "rancher", "k3d" ]:
+    defaults_path = Path(invfactory.repo.working_tree_dir)
+    distributions = find_values(DefaultsFact.DISTRIBUTION, defaults_path)
+    clouds = find_values(DefaultsFact.CLOUD, defaults_path)
+    cloud_regions = {}
+    for cloud in clouds:
+        cloud_regions[cloud] = find_values(DefaultsFact.REGION, defaults_path, cloud=cloud)
+
+    for distribution in distributions:
         navitems[distribution] = {}
-        for cloud in ["cloudscale", "exoscale"]:
+        for cloud in clouds:
             for region in cloud_regions[cloud]:
+                if region == "params":
+                    continue
+                print(f"{distribution=}, {cloud=}, {region=}")
                 inv = invfactory.reclass(distribution, cloud, region)
 
                 navitems[distribution][f"{cloud}/{region}"] =  f"{distribution}/{cloud}_{region}.adoc"

--- a/commodore_defaults_commentator/templates/component_description.adoc.jinja2
+++ b/commodore_defaults_commentator/templates/component_description.adoc.jinja2
@@ -1,16 +1,32 @@
-= Components
+= Components for {{ distribution }}/{{ cloud }}{% if region %}/{{ region }}{% endif %}
+
+This page documents the component versions and configured parameters in `{{repo}}` for the following combination of distribution and cloud provider:
+
+* distribution: `{{ distribution }}`
+* cloud: `{{ cloud }}`
+{% if region %}
+* cloud region: `{{ region }}`
+{% endif %}
+
+The documentation uses `t-foo` and `c-bar` for the tenant and cluster IDs respectively.
+
+== Component versions
+
+|====
+{% for cn, cver in component_versions.items() %}
+| {{ cn }} | {{ cver['url'] }} | {% if 'version' in cver %}{{ cver['version'] }}{% else %}--{%endif%} | `{{ cver.uri|strip_prefix(repo_path) }}`
+{% endfor %}
+|====
+
+== Component parameters
+
 {% for component in components %}
-== {{ component.title }}
+=== {{ component.title }}
 {% if component.docu %}
-=== Documentation
 {% for doc in component.docu %}
 {{ doc }}
 {% endfor %}
 {% endif %}
-=== Parameters
 
-[source]
-----
-{{ component.params }}
-----
+{{ component.params|asciidoc_yaml(component.title, repo_path)  }}
 {% endfor %}

--- a/commodore_defaults_commentator/templates/index.adoc.jinja2
+++ b/commodore_defaults_commentator/templates/index.adoc.jinja2
@@ -1,0 +1,3 @@
+= Commodore global defaults documentation
+
+This is the documentation for the Commodore global defaults at `{{repo_url}}`.

--- a/commodore_defaults_commentator/templates/nav.adoc.jinja2
+++ b/commodore_defaults_commentator/templates/nav.adoc.jinja2
@@ -1,0 +1,8 @@
+xref:index.adoc[Home]
+
+{% for dist, items in navitems.items() %}
+.{{ dist }}
+{% for title, page in items.items() %}
+* xref:{{ page }}[{{ title }}]
+{% endfor %}
+{% endfor %}

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,0 +1,6 @@
+name: commodore-defaults-commentator
+title: "Project Syn: Commodore global defaults documentation"
+version: master
+start_page: ROOT:index.adoc
+nav:
+- modules/ROOT/nav.adoc

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,7 +8,7 @@ python-versions = "*"
 
 [[package]]
 name = "arrow"
-version = "1.2.0"
+version = "1.2.1"
 description = "Better dates & times for Python"
 category = "main"
 optional = false
@@ -101,14 +101,14 @@ chardet = ">=3.0.2"
 
 [[package]]
 name = "boto3"
-version = "1.19.1"
+version = "1.19.2"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.22.1,<1.23.0"
+botocore = ">=1.22.2,<1.23.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -117,7 +117,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.22.1"
+version = "1.22.2"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -258,14 +258,14 @@ python-versions = "*"
 
 [[package]]
 name = "gitdb"
-version = "4.0.7"
+version = "4.0.9"
 description = "Git Object Database"
 category = "main"
 optional = false
-python-versions = ">=3.4"
+python-versions = ">=3.6"
 
 [package.dependencies]
-smmap = ">=3.0.1,<5"
+smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
@@ -326,14 +326,11 @@ six = "*"
 
 [[package]]
 name = "httplib2"
-version = "0.20.1"
+version = "0.18.1"
 description = "A comprehensive HTTP client library."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-pyparsing = ">=2.4.2,<3"
+python-versions = "*"
 
 [[package]]
 name = "hvac"
@@ -657,11 +654,14 @@ tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 
 [[package]]
 name = "pyparsing"
-version = "2.4.7"
+version = "3.0.1"
 description = "Python parsing module"
 category = "main"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pypiwin32"
@@ -784,7 +784,7 @@ six = "*"
 type = "git"
 url = "https://github.com/projectsyn/reclass"
 reference = "feat/params-keep-uris"
-resolved_reference = "c14721c22de9134a2dc1b231cf86b6c441bb03f1"
+resolved_reference = "f0e9c250d8d4cd839120ebadc2749d2bd6491174"
 
 [[package]]
 name = "requests"
@@ -862,11 +862,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "smmap"
-version = "4.0.0"
+version = "5.0.0"
 description = "A pure Python implementation of a sliding window memory map manager"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [[package]]
 name = "syn-commodore"
@@ -998,8 +998,8 @@ addict = [
     {file = "addict-2.2.1.tar.gz", hash = "sha256:f22493f056032f50e4931a82444fcba8ef74c8fc994c5d06aa546a1433c2b8b0"},
 ]
 arrow = [
-    {file = "arrow-1.2.0-py3-none-any.whl", hash = "sha256:8fb7d9d3d4bf90e49e734c22fa077bdd0964135c4b8120de2510575a8d1f620c"},
-    {file = "arrow-1.2.0.tar.gz", hash = "sha256:16fc29bbd9e425e3eb0fef3018297910a0f4568f21116fc31771e2760a50e074"},
+    {file = "arrow-1.2.1-py3-none-any.whl", hash = "sha256:6b2914ef3997d1fd7b37a71ce9dd61a6e329d09e1c7b44f4d3099ca4a5c0933e"},
+    {file = "arrow-1.2.1.tar.gz", hash = "sha256:c2dde3c382d9f7e6922ce636bf0b318a7a853df40ecb383b29192e6c5cc82840"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1030,12 +1030,12 @@ binaryornot = [
     {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
 ]
 boto3 = [
-    {file = "boto3-1.19.1-py3-none-any.whl", hash = "sha256:49ca02fbe8bd74da8f5bba5ae83788ce60354c6628773fa4affff1b58351fc0c"},
-    {file = "boto3-1.19.1.tar.gz", hash = "sha256:a50797af662cc8bec77cda51e92fe0d26f4909780b3dd3430d22c96748c48706"},
+    {file = "boto3-1.19.2-py3-none-any.whl", hash = "sha256:1b8fac5f11ee1d185770d7619f2212e67e636ce190512770d0d36fd162739628"},
+    {file = "boto3-1.19.2.tar.gz", hash = "sha256:11a6035060230e92327d4f10fef6bc44188b2cd68504012bc25ed62ac31d670b"},
 ]
 botocore = [
-    {file = "botocore-1.22.1-py3-none-any.whl", hash = "sha256:0a52801ce5a8835bedfc71a3e1143545e17cc146638d4dd23672055738cac253"},
-    {file = "botocore-1.22.1.tar.gz", hash = "sha256:32897b949415873534bd84c95d82485a5f3ce88fc72638bfd829afa4f97be8d6"},
+    {file = "botocore-1.22.2-py3-none-any.whl", hash = "sha256:681d0d854d08beb9a5727152e95a884439b76cf19fb38d69ca2f17f1404d48ae"},
+    {file = "botocore-1.22.2.tar.gz", hash = "sha256:011360e79a4b843aa6591573cfa61e8eddc99b91adab1dfdb9a2b7f2c8511193"},
 ]
 cachetools = [
     {file = "cachetools-4.2.4-py3-none-any.whl", hash = "sha256:92971d3cb7d2a97efff7c7bb1657f21a8f5fb309a37530537c71b1774189f2d1"},
@@ -1149,8 +1149,8 @@ enum34 = [
     {file = "enum34-1.1.10.tar.gz", hash = "sha256:cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248"},
 ]
 gitdb = [
-    {file = "gitdb-4.0.7-py3-none-any.whl", hash = "sha256:6c4cc71933456991da20917998acbe6cf4fb41eeaab7d6d67fbc05ecd4c865b0"},
-    {file = "gitdb-4.0.7.tar.gz", hash = "sha256:96bf5c08b157a666fec41129e6d327235284cca4c81e92109260f353ba138005"},
+    {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
+    {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
 ]
 gitpython = [
     {file = "GitPython-3.1.3-py3-none-any.whl", hash = "sha256:ef1d60b01b5ce0040ad3ec20bc64f783362d41fa0822a2742d3586e1f49bb8ac"},
@@ -1169,8 +1169,8 @@ google-auth-httplib2 = [
     {file = "google_auth_httplib2-0.1.0-py2.py3-none-any.whl", hash = "sha256:31e49c36c6b5643b57e82617cb3e021e3e1d2df9da63af67252c02fa9c1f4a10"},
 ]
 httplib2 = [
-    {file = "httplib2-0.20.1-py3-none-any.whl", hash = "sha256:8fa4dbf2fbf839b71f8c7837a831e00fcdc860feca99b8bda58ceae4bc53d185"},
-    {file = "httplib2-0.20.1.tar.gz", hash = "sha256:0efbcb8bfbfbc11578130d87d8afcc65c2274c6eb446e59fc674e4d7c972d327"},
+    {file = "httplib2-0.18.1-py3-none-any.whl", hash = "sha256:ca2914b015b6247791c4866782fa6042f495b94401a0f0bd3e1d6e0ba2236782"},
+    {file = "httplib2-0.18.1.tar.gz", hash = "sha256:8af66c1c52c7ffe1aa5dc4bcd7c769885254b0756e6e69f953c7f0ab49a70ba3"},
 ]
 hvac = [
     {file = "hvac-0.10.4-py2.py3-none-any.whl", hash = "sha256:239f5e262db3bb53d6035c95da46bd072a46ce5eac227149c003fc773462a646"},
@@ -1212,22 +1212,12 @@ kapitan = [
     {file = "kapitan-0.29.4.tar.gz", hash = "sha256:0c3c514c5ac0c48b163d6b507537ac620feca2aeeab4c743b18d52427815df4c"},
 ]
 markupsafe = [
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1236,21 +1226,14 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1260,9 +1243,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1350,8 +1330,8 @@ pyjwt = [
     {file = "PyJWT-2.3.0.tar.gz", hash = "sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
-    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+    {file = "pyparsing-3.0.1-py3-none-any.whl", hash = "sha256:fd93fc45c47893c300bd98f5dd1b41c0e783eaeb727e7cea210dcc09d64ce7c3"},
+    {file = "pyparsing-3.0.1.tar.gz", hash = "sha256:84196357aa3566d64ad123d7a3c67b0e597a115c4934b097580e5ce220b91531"},
 ]
 pypiwin32 = [
     {file = "pypiwin32-223-py3-none-any.whl", hash = "sha256:67adf399debc1d5d14dffc1ab5acacb800da569754fafdc576b2a039485aa775"},
@@ -1474,8 +1454,8 @@ six = [
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 smmap = [
-    {file = "smmap-4.0.0-py2.py3-none-any.whl", hash = "sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2"},
-    {file = "smmap-4.0.0.tar.gz", hash = "sha256:7e65386bd122d45405ddf795637b7f7d2b532e7e401d46bbe3fb49b9986d5182"},
+    {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
+    {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
 ]
 syn-commodore = [
     {file = "syn-commodore-0.10.0.tar.gz", hash = "sha256:e2cfed2303f2ad37e710f35622509fe9c1613170a50d5476eac0354ae75bb9bb"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -101,14 +101,14 @@ chardet = ">=3.0.2"
 
 [[package]]
 name = "boto3"
-version = "1.19.0"
+version = "1.19.1"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.22.0,<1.23.0"
+botocore = ">=1.22.1,<1.23.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -117,7 +117,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.22.0"
+version = "1.22.1"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -784,7 +784,7 @@ six = "*"
 type = "git"
 url = "https://github.com/projectsyn/reclass"
 reference = "feat/params-keep-uris"
-resolved_reference = "4ce31efc6481bf4c7285a125957cd693c679682a"
+resolved_reference = "c14721c22de9134a2dc1b231cf86b6c441bb03f1"
 
 [[package]]
 name = "requests"
@@ -1030,12 +1030,12 @@ binaryornot = [
     {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
 ]
 boto3 = [
-    {file = "boto3-1.19.0-py3-none-any.whl", hash = "sha256:d468b1f63f22ccd6b4bfbdebe6fd0c0b4620f38276af965ed139fe3eb85d16bb"},
-    {file = "boto3-1.19.0.tar.gz", hash = "sha256:f93fed6153f7def66f1b17e6794c6ec3bec46229b213d3fa63f1eca126f5e992"},
+    {file = "boto3-1.19.1-py3-none-any.whl", hash = "sha256:49ca02fbe8bd74da8f5bba5ae83788ce60354c6628773fa4affff1b58351fc0c"},
+    {file = "boto3-1.19.1.tar.gz", hash = "sha256:a50797af662cc8bec77cda51e92fe0d26f4909780b3dd3430d22c96748c48706"},
 ]
 botocore = [
-    {file = "botocore-1.22.0-py3-none-any.whl", hash = "sha256:c9894037047a5e118be3e3ae6586ba32de7bb01257c46661874427720d52cde0"},
-    {file = "botocore-1.22.0.tar.gz", hash = "sha256:b78184ff1b1512c8ac00ad2ec1cea513ead930ace95749ed39f9d059aafe0645"},
+    {file = "botocore-1.22.1-py3-none-any.whl", hash = "sha256:0a52801ce5a8835bedfc71a3e1143545e17cc146638d4dd23672055738cac253"},
+    {file = "botocore-1.22.1.tar.gz", hash = "sha256:32897b949415873534bd84c95d82485a5f3ce88fc72638bfd829afa4f97be8d6"},
 ]
 cachetools = [
     {file = "cachetools-4.2.4-py3-none-any.whl", hash = "sha256:92971d3cb7d2a97efff7c7bb1657f21a8f5fb309a37530537c71b1774189f2d1"},


### PR DESCRIPTION
* Jinja filter and machinery to annotate component parameters with source locations
* Extended template to show component versions for each distribution/cloud combination
* Render nav.adoc and index.adoc

Open points:
- [ ] Extract distributions, clouds and cloud regions from global defaults directory structure
- [ ] Include component defaults in documented parameters
- [ ] Nicer formatting of navigation entries
- [ ] Python lints
- [ ] Python tests